### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/kentwong1/3a4ab6fb-6f2b-4ab5-a1ea-231db673f1e1/eac14e27-f3f1-4e94-885b-6bdaeed72628/_apis/work/boardbadge/44a04a82-b02f-4469-9867-40ca2ebdf0bc)](https://dev.azure.com/kentwong1/3a4ab6fb-6f2b-4ab5-a1ea-231db673f1e1/_boards/board/t/eac14e27-f3f1-4e94-885b-6bdaeed72628/Microsoft.RequirementCategory)
 # SENG513
 SENG 513 Web Based Systems Group Repo


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/kentwong1/3a4ab6fb-6f2b-4ab5-a1ea-231db673f1e1/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.